### PR TITLE
Handle message size more than 4096 characters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ mvnw.cmd
 **/application-qa.yml
 *.db
 lib/
+bin/
 
 ### STS ###
 .apt_generated

--- a/src/main/java/io/github/trashemail/Configurations/TelegramConfg.java
+++ b/src/main/java/io/github/trashemail/Configurations/TelegramConfg.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 public class TelegramConfg{
     private String botToken;
     private String url;
+    private int size=4096;
 
     public String getUrl() {
         return url;
@@ -23,5 +24,13 @@ public class TelegramConfg{
 
     public void setBotToken(String botToken) {
         this.botToken = botToken;
+    }
+
+    public int getSize() {
+    	return size;
+    }
+
+    public void setSize(int size) {
+    	this.size = size;
     }
 }

--- a/src/main/java/io/github/trashemail/Configurations/TelegramConfg.java
+++ b/src/main/java/io/github/trashemail/Configurations/TelegramConfg.java
@@ -8,7 +8,7 @@ import org.springframework.context.annotation.Configuration;
 public class TelegramConfg{
     private String botToken;
     private String url;
-    private int size=4096;
+    private int size;
 
     public String getUrl() {
         return url;
@@ -27,10 +27,10 @@ public class TelegramConfg{
     }
 
     public int getSize() {
-    	return size;
+        return size;
     }
 
     public void setSize(int size) {
-    	this.size = size;
+        this.size = size;
     }
 }

--- a/src/main/java/io/github/trashemail/Telegram/SendTelegramMessage.java
+++ b/src/main/java/io/github/trashemail/Telegram/SendTelegramMessage.java
@@ -2,6 +2,8 @@ package io.github.trashemail.Telegram;
 
 import io.github.trashemail.Configurations.TelegramConfg;
 
+import java.util.ArrayList;
+
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -29,23 +31,32 @@ public class SendTelegramMessage {
 
         HttpHeaders headers = new HttpHeaders();
         headers.setContentType(MediaType.APPLICATION_FORM_URLENCODED);
-
-        MultiValueMap<String, String> data = new LinkedMultiValueMap<>();
-        data.add("chat_id", chatId);
-        data.add("text", message);
-
-        HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<MultiValueMap<String, String>>(data, headers);
-
-        RestTemplate restTemplate = new RestTemplate();
-        ResponseEntity response = restTemplate.postForEntity(
-                telegramURI,
-                request,
-                String.class);
-
-        if(response.getStatusCode() == HttpStatus.OK){
-            log.debug("Message sent to user: " + chatId);
+        
+        // Checking the message size and do splitting into chunks if required
+        int maxMessageSize = telegramConfg.getSize();
+        ArrayList<String> split = new ArrayList<>();
+        for (int i = 0; i <= message.length() / maxMessageSize; i++) {
+        	split.add(message.substring(i * maxMessageSize, Math.min((i + 1) * maxMessageSize, message.length())));
         }
-        else
-            log.error("Unable to send message to user: " + chatId);
+
+        for (int i = 0; i < split.size(); i++) {
+        	MultiValueMap<String, String> data = new LinkedMultiValueMap<>();
+        	data.add("chat_id", chatId);
+        	data.add("text", split.get(i));
+
+        	HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<MultiValueMap<String, String>>(data, headers);
+
+        	RestTemplate restTemplate = new RestTemplate();
+        	ResponseEntity response = restTemplate.postForEntity(
+        			telegramURI,
+        			request,
+        			String.class);
+
+        	if(response.getStatusCode() == HttpStatus.OK){
+        		log.debug("Message sent to user: " + chatId);
+        	}
+        	else
+        		log.error("Unable to send message to user: " + chatId);
+        }
     }
 }

--- a/src/main/java/io/github/trashemail/Telegram/SendTelegramMessage.java
+++ b/src/main/java/io/github/trashemail/Telegram/SendTelegramMessage.java
@@ -20,6 +20,9 @@ import org.springframework.web.client.RestTemplate;
 public class SendTelegramMessage {
     @Autowired
     private TelegramConfg telegramConfg;
+    
+    @Autowired
+    RestTemplate restTemplate;
 
     private static final Logger log = LoggerFactory.getLogger(SendTelegramMessage.class);
 
@@ -46,7 +49,6 @@ public class SendTelegramMessage {
 
         	HttpEntity<MultiValueMap<String, String>> request = new HttpEntity<MultiValueMap<String, String>>(data, headers);
 
-        	RestTemplate restTemplate = new RestTemplate();
         	ResponseEntity response = restTemplate.postForEntity(
         			telegramURI,
         			request,


### PR DESCRIPTION
- Since Telegram sendMessage imposes a limit of 4096 characters, Dividing the message into the size of 4096 chunks and sending it multiple times
- Solving issue #7 