### PR TITLE
Replace custom email parser with MimeMessageParser

### DIFF
--- a/src/main/java/io/github/trashemail/EmailInteraction/ImapClient.java
+++ b/src/main/java/io/github/trashemail/EmailInteraction/ImapClient.java
@@ -16,7 +16,6 @@ import javax.annotation.PostConstruct;
 import javax.mail.*;
 import javax.mail.event.MessageCountAdapter;
 import javax.mail.event.MessageCountEvent;
-import java.io.IOException;
 import java.util.Properties;
 
 @Configuration
@@ -72,7 +71,7 @@ public class ImapClient {
                     for (Message message : messages) {
                         try {
                             forwardMailsToTelegram.sendToTelegram(message);
-                        } catch (MessagingException | IOException e) {
+                        } catch (Exception e) {
                             e.printStackTrace();
                         }
                     }

--- a/src/main/java/io/github/trashemail/Telegram/ForwardMailsToTelegram.java
+++ b/src/main/java/io/github/trashemail/Telegram/ForwardMailsToTelegram.java
@@ -9,8 +9,6 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.stereotype.Component;
 
 import javax.mail.Message;
-import javax.mail.MessagingException;
-import java.io.IOException;
 
 @Component
 public class ForwardMailsToTelegram {
@@ -21,7 +19,7 @@ public class ForwardMailsToTelegram {
 
     private static final Logger log = LoggerFactory.getLogger(ForwardMailsToTelegram.class);
 
-    public void sendToTelegram(Message message) throws MessagingException, IOException {
+    public void sendToTelegram(Message message) throws Exception {
         String emailFor = message.getAllRecipients()[0].toString();
         User user = userRepository.findByEmailId(emailFor);
         MailParser parsedMail = new MailParser(message);


### PR DESCRIPTION
- Due to this current custom parser, few of the html mails are getting missed out.
- Now replacing it with Apache's MimeMessageParser(https://commons.apache.org/proper/commons-email/apidocs/org/apache/commons/mail/util/MimeMessageParser.html) 
- Solving issue #18 